### PR TITLE
Refactor: externalize LLM engine selection via config.yaml

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,2 @@
+llm:
+  engine: "phi3"       # "phi3" 또는 다른 모델

--- a/config/config_loader.py
+++ b/config/config_loader.py
@@ -1,0 +1,6 @@
+import yaml
+from pathlib import Path
+
+def load_config(path: str = "config/config.yaml") -> dict:
+    with open(Path(path), "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)

--- a/core/llm_factory.py
+++ b/core/llm_factory.py
@@ -1,0 +1,15 @@
+from config.config_loader import load_config
+from phi3_mini_engine import Phi3MiniEngine
+from chat_gpt_engine import ChatGPTEngine
+
+def get_llm_engine():
+    config = load_config()
+    engine_type = config["llm"]["engine"]
+    engine_type.lower() # lowercase
+
+    if engine_type == "phi3":
+        return Phi3MiniEngine()
+    elif engine_type == "gpt":
+        return ChatGPTEngine()
+    else:
+        raise ValueError(f"Unknown LLM engine type: {engine_type}")

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ from image_gen_engine import *
 
 
 
-# ex) ai_module.py 파일의 ask_ai 메서드라고 가정 
+# ex) ai_module.py 파일의 ask_ai 메서드라고 가정
 # from ai_module import ask_ai
 
 class MainApp(QMainWindow):
@@ -45,14 +45,9 @@ class MainApp(QMainWindow):
         # initial state
         self.update_page_display()
         
-        # GPT API 활용
-        # from chat_gpt_engine import ChatGPTEngine
-        # # initialization for llm engine
-        # self.llm_engine = ChatGPTEngine()
-        
-        # phi3_mini 활용
-        from phi3_mini_engine import Phi3MiniEngine
-        self.llm_engine = Phi3MiniEngine()
+        # llm 모델 가져오기 (phi3_mini 활용)
+        from core.llm_factory import get_llm_engine
+        self.llm_engine = get_llm_engine()
         self.story_parts: List[str] = []
         self.chat_controller = ChatController(self._on_chat_reply, self.llm_engine)
 


### PR DESCRIPTION
### Summary
Previously, switching between LLM engines required modifying `main.py` directly.  
This PR refactors engine initialization to read from a configuration file, eliminating the need for code changes when selecting models.

### Changes
- Added `config.yaml` with LLM engine selection:
    ```yaml
      llm:
        engine: "phi3"   # "phi3" or other models
    ```

- Added `config_loader.py` to parse YAML configuration.
- Introduced `llm_factory.py` to instantiate the correct engine based on the config.
- Removed hardcoded engine logic from `main.py.`

### Benefits
- Decouples configuration from application code.
- Enables switching LLM models by editing `config.yaml` instead of code.
- Lays groundwork for adding new engines with minimal changes.